### PR TITLE
refactor: Update delete action to a patch action instead

### DIFF
--- a/app/controllers/api/v0/subscriptions_controller.rb
+++ b/app/controllers/api/v0/subscriptions_controller.rb
@@ -7,7 +7,7 @@ class Api::V0::SubscriptionsController < ApplicationController
     render json: SubscriptionSerializer.new(@subscription), status: 201
   end
 
-  def destroy
+  def update
     @subscription = Subscription.find_by_id!(params[:id])
     @subscription.change_status_to_cancelled
     render json: SubscriptionSerializer.new(@subscription), status: 200

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   # root "articles#index"
   namespace :api do
     namespace :v0 do
-      resources :subscriptions, only: [:create, :destroy]
+      resources :subscriptions, only: [:create, :update]
       resources :customers, only: [:index] do
         resources :subscriptions, only: [:index], controller: 'customers/subscriptions'
       end

--- a/spec/requests/api/v0/delete_subscription_spec.rb
+++ b/spec/requests/api/v0/delete_subscription_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'DELETE /api/v0/subscriptions/:id', type: :request do
 
       headers = { 'CONTENT_TYPE' => 'application/json' }
 
-      delete "/api/v0/subscriptions/#{subscription.id}", headers: headers
+      patch "/api/v0/subscriptions/#{subscription.id}", headers: headers
       
       json = JSON.parse(response.body, symbolize_names: true)
 
@@ -28,7 +28,7 @@ RSpec.describe 'DELETE /api/v0/subscriptions/:id', type: :request do
     it 'returns an error if no subscription exists with that id' do
       headers = { 'CONTENT_TYPE' => 'application/json' }
 
-      delete "/api/v0/subscriptions/5", headers: headers
+      patch "/api/v0/subscriptions/5", headers: headers
       
       json = JSON.parse(response.body, symbolize_names: true)
 


### PR DESCRIPTION
This PR closes:
- Refactor delete action to patch action instead, made more sense with just updating status of a sub